### PR TITLE
fix: Add 'name' column type to decodeText (#76)

### DIFF
--- a/decode.ts
+++ b/decode.ts
@@ -188,6 +188,7 @@ function decodeText(value: Uint8Array, typeOid: number): any {
     case Oid.inet:
     case Oid.cidr:
     case Oid.macaddr:
+    case Oid.name:
       return strValue;
     case Oid.bool:
       return strValue[0] === "t";


### PR DESCRIPTION
Resolves #76 

This PR fixes 'name' column type parsing method is not implemented.
This change ensures that the 'name' type is handled properly and the following query can be executed without error.

    SELECT * FROM information_schema.tables