### PR TITLE
Fix hash md5 password

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -45,8 +45,8 @@ function md5(bytes: Uint8Array): string {
 //  concat('md5', md5(concat(md5(concat(password, username)), random-salt))).
 // (Keep in mind the md5() function returns its result as a hex string.)
 export function hashMd5Password(
-  username: string,
   password: string,
+  username: string,
   salt: Uint8Array
 ): string {
   const innerHash = md5(encoder.encode(password + username));


### PR DESCRIPTION
This PR fixes hashMd5Password function. 

This function is used like the below in `connection.ts`:
```ts
    const password = hashMd5Password(
      this.connParams.password,
      this.connParams.user,
      salt
    );
```
However the paramter order of user and password is reversed in the function definition, and therefore this produces wrong md5 hash for authentication.

I checked I can connect to my postgres instance on AWS RDS with this patch applied.