### PR TITLE
refactor: separate test_deps.ts from deps.ts

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -6,19 +6,6 @@ export {
 export { copyBytes } from "https://deno.land/std@v0.31.0/io/util.ts";
 
 export {
-  assert,
-  assertEquals,
-  assertStrContains,
-  assertThrowsAsync
-} from "https://deno.land/std@v0.31.0/testing/asserts.ts";
-
-export {
-  runTests,
-  test,
-  TestFunction
-} from "https://deno.land/std@v0.31.0/testing/mod.ts";
-
-export {
   Deferred,
   deferred
 } from "https://deno.land/std@v0.31.0/util/async.ts";

--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,5 @@
 #! /usr/bin/env deno run --allow-net --allow-env test.ts
-import { runTests } from "./deps.ts";
+import { runTests } from "./test_deps.ts";
 
 import "./tests/data_types.ts";
 import "./tests/queries.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,0 +1,13 @@
+export * from "./deps.ts";
+export {
+  assert,
+  assertEquals,
+  assertStrContains,
+  assertThrowsAsync
+} from "https://deno.land/std@v0.31.0/testing/asserts.ts";
+
+export {
+  runTests,
+  test,
+  TestFunction
+} from "https://deno.land/std@v0.31.0/testing/mod.ts";

--- a/tests/client.ts
+++ b/tests/client.ts
@@ -1,4 +1,4 @@
-import { test, assert, assertStrContains } from "../deps.ts";
+import { test, assert, assertStrContains } from "../test_deps.ts";
 import { Client, PostgresError } from "../mod.ts";
 import { TEST_CONNECTION_PARAMS } from "./constants.ts";
 

--- a/tests/connection_params.ts
+++ b/tests/connection_params.ts
@@ -1,4 +1,4 @@
-import { test, assertEquals, assertStrContains } from "../deps.ts";
+import { test, assertEquals, assertStrContains } from "../test_deps.ts";
 import { ConnectionParams } from "../connection_params.ts";
 
 test(async function dsnStyleParameters() {

--- a/tests/data_types.ts
+++ b/tests/data_types.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "../deps.ts";
+import { assertEquals } from "../test_deps.ts";
 import { Client } from "../mod.ts";
 import { TEST_CONNECTION_PARAMS } from "./constants.ts";
 import { getTestClient } from "./helpers.ts";

--- a/tests/encode.ts
+++ b/tests/encode.ts
@@ -1,4 +1,4 @@
-import { test, assertEquals } from "../deps.ts";
+import { test, assertEquals } from "../test_deps.ts";
 import { encode } from "../encode.ts";
 
 // internally `encode` uses `getTimezoneOffset` to encode Date

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,4 +1,4 @@
-import { test, TestFunction } from "../deps.ts";
+import { test, TestFunction } from "../test_deps.ts";
 import { Client } from "../client.ts";
 
 export function getTestClient(client: Client, defSetupQueries?: Array<string>) {

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   TestFunction,
   assertThrowsAsync
-} from "../deps.ts";
+} from "../test_deps.ts";
 import { Pool } from "../pool.ts";
 import { delay } from "../utils.ts";
 import { TEST_CONNECTION_PARAMS, DEFAULT_SETUP } from "./constants.ts";

--- a/tests/queries.ts
+++ b/tests/queries.ts
@@ -1,4 +1,4 @@
-import { test, assertEquals, TestFunction } from "../deps.ts";
+import { test, assertEquals, TestFunction } from "../test_deps.ts";
 import { Client } from "../mod.ts";
 import { TEST_CONNECTION_PARAMS, DEFAULT_SETUP } from "./constants.ts";
 import { getTestClient } from "./helpers.ts";

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,4 +1,4 @@
-import { test, assertEquals } from "../deps.ts";
+import { test, assertEquals } from "../test_deps.ts";
 import { parseDsn, DsnResult } from "../utils.ts";
 
 test(function testParseDsn() {


### PR DESCRIPTION
This PR separates `test_deps.ts` from `deps.ts` and reduces the download size of the library.

closes #84 