### PR TITLE
Add support for oid types

### DIFF
--- a/decode.ts
+++ b/decode.ts
@@ -191,6 +191,17 @@ function decodeText(value: Uint8Array, typeOid: number): any {
     case Oid.macaddr:
     case Oid.name:
     case Oid.uuid:
+    case Oid.oid:
+    case Oid.regproc:
+    case Oid.regprocedure:
+    case Oid.regoper:
+    case Oid.regoperator:
+    case Oid.regclass:
+    case Oid.regtype:
+    case Oid.regrole:
+    case Oid.regnamespace:
+    case Oid.regconfig:
+    case Oid.regdictionary:
       return strValue;
     case Oid.bool:
       return strValue[0] === "t";

--- a/tests/data_types.ts
+++ b/tests/data_types.ts
@@ -54,3 +54,58 @@ testClient(async function cidr() {
   );
   assertEquals(selectRes.rows, [[cidr]]);
 });
+
+testClient(async function oid() {
+  const result = await CLIENT.query(`SELECT 1::oid`);
+  assertEquals(result.rows, [['1']]);
+});
+
+testClient(async function regproc() {
+  const result = await CLIENT.query(`SELECT 'starts_with'::regproc`);
+  assertEquals(result.rows, [['starts_with']]);
+});
+
+testClient(async function regprocedure() {
+  const result = await CLIENT.query(`SELECT 'sum(integer)'::regprocedure`);
+  assertEquals(result.rows, [['sum(integer)']]);
+});
+
+testClient(async function regoper() {
+  const result = await CLIENT.query(`SELECT '!'::regoper`);
+  assertEquals(result.rows, [['!']]);
+});
+
+testClient(async function regoperator() {
+  const result = await CLIENT.query(`SELECT '!(bigint,NONE)'::regoperator`);
+  assertEquals(result.rows, [['!(bigint,NONE)']]);
+});
+
+testClient(async function regclass() {
+  const result = await CLIENT.query(`SELECT 'data_types'::regclass`);
+  assertEquals(result.rows, [['data_types']]);
+});
+
+testClient(async function regtype() {
+  const result = await CLIENT.query(`SELECT 'integer'::regtype`);
+  assertEquals(result.rows, [['integer']]);
+});
+
+testClient(async function regrole() {
+  const result = await CLIENT.query(`SELECT ($1)::regrole`, TEST_CONNECTION_PARAMS.user);
+  assertEquals(result.rows, [[TEST_CONNECTION_PARAMS.user]]);
+});
+
+testClient(async function regnamespace() {
+  const result = await CLIENT.query(`SELECT 'public'::regnamespace;`);
+  assertEquals(result.rows, [['public']]);
+});
+
+testClient(async function regconfig() {
+  const result = await CLIENT.query(`SElECT 'english'::regconfig`);
+  assertEquals(result.rows, [['english']]);
+});
+
+testClient(async function regdictionary() {
+  const result = await CLIENT.query(`SElECT 'simple'::regdictionary`);
+  assertEquals(result.rows, [['simple']]);
+});

--- a/tests/data_types.ts
+++ b/tests/data_types.ts
@@ -61,8 +61,8 @@ testClient(async function oid() {
 });
 
 testClient(async function regproc() {
-  const result = await CLIENT.query(`SELECT 'starts_with'::regproc`);
-  assertEquals(result.rows, [["starts_with"]]);
+  const result = await CLIENT.query(`SELECT 'now'::regproc`);
+  assertEquals(result.rows, [["now"]]);
 });
 
 testClient(async function regprocedure() {

--- a/tests/data_types.ts
+++ b/tests/data_types.ts
@@ -57,55 +57,58 @@ testClient(async function cidr() {
 
 testClient(async function oid() {
   const result = await CLIENT.query(`SELECT 1::oid`);
-  assertEquals(result.rows, [['1']]);
+  assertEquals(result.rows, [["1"]]);
 });
 
 testClient(async function regproc() {
   const result = await CLIENT.query(`SELECT 'starts_with'::regproc`);
-  assertEquals(result.rows, [['starts_with']]);
+  assertEquals(result.rows, [["starts_with"]]);
 });
 
 testClient(async function regprocedure() {
   const result = await CLIENT.query(`SELECT 'sum(integer)'::regprocedure`);
-  assertEquals(result.rows, [['sum(integer)']]);
+  assertEquals(result.rows, [["sum(integer)"]]);
 });
 
 testClient(async function regoper() {
   const result = await CLIENT.query(`SELECT '!'::regoper`);
-  assertEquals(result.rows, [['!']]);
+  assertEquals(result.rows, [["!"]]);
 });
 
 testClient(async function regoperator() {
   const result = await CLIENT.query(`SELECT '!(bigint,NONE)'::regoperator`);
-  assertEquals(result.rows, [['!(bigint,NONE)']]);
+  assertEquals(result.rows, [["!(bigint,NONE)"]]);
 });
 
 testClient(async function regclass() {
   const result = await CLIENT.query(`SELECT 'data_types'::regclass`);
-  assertEquals(result.rows, [['data_types']]);
+  assertEquals(result.rows, [["data_types"]]);
 });
 
 testClient(async function regtype() {
   const result = await CLIENT.query(`SELECT 'integer'::regtype`);
-  assertEquals(result.rows, [['integer']]);
+  assertEquals(result.rows, [["integer"]]);
 });
 
 testClient(async function regrole() {
-  const result = await CLIENT.query(`SELECT ($1)::regrole`, TEST_CONNECTION_PARAMS.user);
+  const result = await CLIENT.query(
+    `SELECT ($1)::regrole`,
+    TEST_CONNECTION_PARAMS.user
+  );
   assertEquals(result.rows, [[TEST_CONNECTION_PARAMS.user]]);
 });
 
 testClient(async function regnamespace() {
   const result = await CLIENT.query(`SELECT 'public'::regnamespace;`);
-  assertEquals(result.rows, [['public']]);
+  assertEquals(result.rows, [["public"]]);
 });
 
 testClient(async function regconfig() {
   const result = await CLIENT.query(`SElECT 'english'::regconfig`);
-  assertEquals(result.rows, [['english']]);
+  assertEquals(result.rows, [["english"]]);
 });
 
 testClient(async function regdictionary() {
   const result = await CLIENT.query(`SElECT 'simple'::regdictionary`);
-  assertEquals(result.rows, [['simple']]);
+  assertEquals(result.rows, [["simple"]]);
 });


### PR DESCRIPTION
- This PR closes #88.
- Added support for oid types.
  - https://www.postgresql.org/docs/11/datatype-oid.html
- Ran `deno fmt` against `decode.ts` and `tests/data_types.ts`.