### PR TITLE
Fix typos on PostgresError Interface

### DIFF
--- a/error.ts
+++ b/error.ts
@@ -10,11 +10,11 @@ export interface ErrorFields {
   internalPosition?: string;
   internalQuery?: string;
   where?: string;
-  schemaName?: string;
+  schema?: string;
   table?: string;
   column?: string;
   dataType?: string;
-  contraint?: string;
+  constraint?: string;
   file?: string;
   line?: string;
   routine?: string;


### PR DESCRIPTION
Fixes #103 

Fixed some typos on PostgresError field interface.

I think the parameter assignation should be handled differently, cause currently it is overlooking the interface and making it hard to spot errors like this