### PR TITLE
chore: bump Deno to v0.39.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: generic
 
 install:
-  - curl -fsSL https://deno.land/x/install/install.sh | sh -s v0.35.0
+  - curl -fsSL https://deno.land/x/install/install.sh | sh -s v0.39.0
   - export PATH="$HOME/.deno/bin:$PATH"
 
 services:

--- a/connection.ts
+++ b/connection.ts
@@ -36,13 +36,13 @@ import { ConnectionParams } from "./connection_params.ts";
 
 export enum Format {
   TEXT = 0,
-  BINARY = 1
+  BINARY = 1,
 }
 
 enum TransactionStatus {
   Idle = "I",
   IdleInTransaction = "T",
-  InFailedTransaction = "E"
+  InFailedTransaction = "E",
 }
 
 export class Message {
@@ -51,7 +51,7 @@ export class Message {
   constructor(
     public type: string,
     public byteCount: number,
-    public body: Uint8Array
+    public body: Uint8Array,
   ) {
     this.reader = new PacketReader(body);
   }
@@ -65,7 +65,7 @@ export class Column {
     public typeOid: number,
     public columnLength: number,
     public typeModifier: number,
-    public format: Format
+    public format: Format,
   ) {}
 }
 
@@ -111,7 +111,7 @@ export class Connection {
     // TODO: recognize other parameters
     (["user", "database", "application_name"] as Array<
       keyof ConnectionParams
-    >).forEach(function(key) {
+    >).forEach(function (key) {
       const val = connParams[key];
       writer.addCString(key).addCString(val);
     });
@@ -138,7 +138,7 @@ export class Connection {
     const { host, port } = this.connParams;
     this.conn = await Deno.connect({
       port: parseInt(port, 10),
-      hostname: host
+      hostname: host,
     });
 
     this.bufReader = new BufReader(this.conn);
@@ -230,7 +230,7 @@ export class Connection {
     const password = hashMd5Password(
       this.connParams.password,
       this.connParams.user,
-      salt
+      salt,
     );
     const buffer = this.packetWriter.addCString(password).flush(0x70);
 
@@ -253,7 +253,7 @@ export class Connection {
   private _processReadyForQuery(msg: Message) {
     const txStatus = msg.reader.readByte();
     this._transactionStatus = String.fromCharCode(
-      txStatus
+      txStatus,
     ) as TransactionStatus;
   }
 
@@ -262,7 +262,7 @@ export class Connection {
 
     if (msg.type !== "Z") {
       throw new Error(
-        `Unexpected message type: ${msg.type}, expected "Z" (ReadyForQuery)`
+        `Unexpected message type: ${msg.type}, expected "Z" (ReadyForQuery)`,
       );
     }
 
@@ -363,7 +363,7 @@ export class Connection {
     if (hasBinaryArgs) {
       this.packetWriter.addInt16(query.args.length);
 
-      query.args.forEach(arg => {
+      query.args.forEach((arg) => {
         this.packetWriter.addInt16(arg instanceof Uint8Array ? 1 : 0);
       });
     } else {
@@ -372,7 +372,7 @@ export class Connection {
 
     this.packetWriter.addInt16(query.args.length);
 
-    query.args.forEach(arg => {
+    query.args.forEach((arg) => {
       if (arg === null || typeof arg === "undefined") {
         this.packetWriter.addInt32(-1);
       } else if (arg instanceof Uint8Array) {
@@ -546,7 +546,7 @@ export class Connection {
         msg.reader.readInt32(), // dataTypeOid
         msg.reader.readInt16(), // column
         msg.reader.readInt32(), // typeModifier
-        msg.reader.readInt16() // format
+        msg.reader.readInt16(), // format
       );
       columns.push(column);
     }

--- a/connection_params.ts
+++ b/connection_params.ts
@@ -9,7 +9,7 @@ function getPgEnv(): IConnectionParams {
       port: env.PGPORT,
       user: env.PGUSER,
       password: env.PGPASSWORD,
-      application_name: env.PGAPPNAME
+      application_name: env.PGAPPNAME,
     };
   } catch (e) {
     // PermissionDenied (--allow-env not passed)
@@ -19,7 +19,7 @@ function getPgEnv(): IConnectionParams {
 
 function selectFrom(
   sources: Array<IConnectionParams>,
-  key: keyof IConnectionParams
+  key: keyof IConnectionParams,
 ): string | undefined {
   for (const source of sources) {
     if (source[key]) {
@@ -32,7 +32,7 @@ function selectFrom(
 
 function selectFromWithDefault(
   sources: Array<IConnectionParams>,
-  key: keyof typeof DEFAULT_CONNECTION_PARAMS
+  key: keyof typeof DEFAULT_CONNECTION_PARAMS,
 ): string {
   return selectFrom(sources, key) || DEFAULT_CONNECTION_PARAMS[key];
 }
@@ -40,7 +40,7 @@ function selectFromWithDefault(
 const DEFAULT_CONNECTION_PARAMS = {
   host: "127.0.0.1",
   port: "5432",
-  application_name: "deno_postgres"
+  application_name: "deno_postgres",
 };
 
 export interface IConnectionParams {
@@ -83,35 +83,37 @@ export class ConnectionParams {
       config = dsn;
     }
 
-    let potentiallyNull: { [K in keyof IConnectionParams]?: string; } = {
+    let potentiallyNull: { [K in keyof IConnectionParams]?: string } = {
       database: selectFrom([config, pgEnv], "database"),
-      user: selectFrom([config, pgEnv], "user")
+      user: selectFrom([config, pgEnv], "user"),
     };
 
     this.host = selectFromWithDefault([config, pgEnv], "host");
     this.port = selectFromWithDefault([config, pgEnv], "port");
     this.application_name = selectFromWithDefault(
       [config, pgEnv],
-      "application_name"
+      "application_name",
     );
     this.password = selectFrom([config, pgEnv], "password");
 
     const missingParams: string[] = [];
 
-    (["database", "user"] as Array<keyof IConnectionParams>).forEach(param => {
-      if (potentiallyNull[param]) {
-        this[param] = potentiallyNull[param]!;
-      } else {
-        missingParams.push(param);
-      }
-    });
+    (["database", "user"] as Array<keyof IConnectionParams>).forEach(
+      (param) => {
+        if (potentiallyNull[param]) {
+          this[param] = potentiallyNull[param]!;
+        } else {
+          missingParams.push(param);
+        }
+      },
+    );
 
     if (missingParams.length) {
       throw new ConnectionParamsError(
         `Missing connection parameters: ${missingParams.join(
-          ", "
+          ", ",
         )}. Connection parameters can be read 
-        from environment only if Deno is run with env permission (deno run --allow-env)`
+        from environment only if Deno is run with env permission (deno run --allow-env)`,
       );
     }
   }

--- a/deferred.ts
+++ b/deferred.ts
@@ -9,7 +9,7 @@ export class DeferredStack<T> {
   constructor(
     max?: number,
     ls?: Iterable<T>,
-    private _creator?: () => Promise<T>
+    private _creator?: () => Promise<T>,
   ) {
     this._maxSize = max || 10;
     this._array = ls ? [...ls] : [];

--- a/deps.ts
+++ b/deps.ts
@@ -1,13 +1,13 @@
 export {
   BufReader,
   BufWriter
-} from "https://deno.land/std@v0.35.0/io/bufio.ts";
+} from "https://deno.land/std@v0.39.0/io/bufio.ts";
 
-export { copyBytes } from "https://deno.land/std@v0.35.0/io/util.ts";
+export { copyBytes } from "https://deno.land/std@v0.39.0/io/util.ts";
 
 export {
   Deferred,
   deferred
-} from "https://deno.land/std@v0.35.0/util/async.ts";
+} from "https://deno.land/std@v0.39.0/util/async.ts";
 
-export { Hash } from "https://deno.land/x/checksum@1.0.1/mod.ts";
+export { Hash } from "https://deno.land/x/checksum@1.2.0/mod.ts";

--- a/encode.ts
+++ b/encode.ts
@@ -73,7 +73,7 @@ function encodeArray(array: Array<unknown>): string {
 
 function encodeBytes(value: Uint8Array): string {
   let hex = Array.from(value)
-    .map(val => (val < 10 ? `0${val.toString(16)}` : val.toString(16)))
+    .map((val) => (val < 10 ? `0${val.toString(16)}` : val.toString(16)))
     .join("");
   return `\\x${hex}`;
 }

--- a/oid.ts
+++ b/oid.ts
@@ -165,5 +165,5 @@ export const Oid = {
   regnamespace: 4089,
   _regnamespace: 4090,
   regrole: 4096,
-  _regrole: 4097
+  _regrole: 4097,
 };

--- a/pool.ts
+++ b/pool.ts
@@ -89,8 +89,10 @@ export class Pool {
 
   async end(): Promise<void> {
     await this._ready;
-    const ending = this._connections.map(c => c.end());
-    await Promise.all(ending);
+    while (this.available > 0) {
+      const conn = await this._availableConnections.pop();
+      await conn.end();
+    }
   }
 
   // Support `using` module

--- a/pool.ts
+++ b/pool.ts
@@ -15,7 +15,7 @@ export class Pool {
   constructor(
     connectionParams: IConnectionParams,
     maxSize: number,
-    lazy?: boolean
+    lazy?: boolean,
   ) {
     this._connectionParams = new ConnectionParams(connectionParams);
     this._maxSize = maxSize;
@@ -54,7 +54,7 @@ export class Pool {
     this._availableConnections = new DeferredStack(
       this._maxSize,
       this._connections,
-      this._createConnection.bind(this)
+      this._createConnection.bind(this),
     );
   }
 

--- a/query.ts
+++ b/query.ts
@@ -49,7 +49,7 @@ export class QueryResult {
   }
 
   rowsOfObjects() {
-    return this.rows.map(row => {
+    return this.rows.map((row) => {
       const rv: { [key: string]: any } = {};
       this.rowDescription.columns.forEach((column, index) => {
         rv[column.name] = row[index];

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -4,4 +4,4 @@ export {
   assertEquals,
   assertStrContains,
   assertThrowsAsync
-} from "https://deno.land/std@v0.35.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.39.0/testing/asserts.ts";

--- a/tests/connection_params.ts
+++ b/tests/connection_params.ts
@@ -4,7 +4,7 @@ import { ConnectionParams } from "../connection_params.ts";
 
 test(async function dsnStyleParameters() {
   const p = new ConnectionParams(
-    "postgres://some_user@some_host:10101/deno_postgres"
+    "postgres://some_user@some_host:10101/deno_postgres",
   );
 
   assertEquals(p.database, "deno_postgres");
@@ -18,7 +18,7 @@ test(async function objectStyleParameters() {
     user: "some_user",
     host: "some_host",
     port: "10101",
-    database: "deno_postgres"
+    database: "deno_postgres",
   });
 
   assertEquals(p.database, "deno_postgres");
@@ -52,7 +52,7 @@ test(async function envParameters() {
 test(async function defaultParameters() {
   const p = new ConnectionParams({
     database: "deno_postgres",
-    user: "deno_postgres"
+    user: "deno_postgres",
   });
   assertEquals(p.database, "deno_postgres");
   assertEquals(p.user, "deno_postgres");
@@ -71,7 +71,7 @@ test(async function requiredParameters() {
     assertEquals(e.name, "ConnectionParamsError");
     assertStrContains(
       e.message,
-      "Missing connection parameters: database, user"
+      "Missing connection parameters: database, user",
     );
   }
   assertEquals(thrown, true);

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -8,7 +8,7 @@ export const DEFAULT_SETUP = [
   `INSERT INTO timestamps(dt) VALUES('2019-02-10T10:30:40.005+04:30');`,
   "DROP TABLE IF EXISTS bytes;",
   "CREATE TABLE bytes(b bytea);",
-  "INSERT INTO bytes VALUES(E'foo\\\\000\\\\200\\\\\\\\\\\\377')"
+  "INSERT INTO bytes VALUES(E'foo\\\\000\\\\200\\\\\\\\\\\\377')",
 ];
 
 export const TEST_CONNECTION_PARAMS = {
@@ -16,5 +16,5 @@ export const TEST_CONNECTION_PARAMS = {
   password: "test",
   database: "deno_postgres",
   host: "127.0.0.1",
-  port: "5432"
+  port: "5432",
 };

--- a/tests/data_types.ts
+++ b/tests/data_types.ts
@@ -9,7 +9,7 @@ const SETUP = [
      inet_t inet,
      macaddr_t macaddr,
      cidr_t cidr
-  );`
+  );`,
 ];
 
 const CLIENT = new Client(TEST_CONNECTION_PARAMS);
@@ -20,11 +20,11 @@ testClient(async function inet() {
   const inet = "127.0.0.1";
   const insertRes = await CLIENT.query(
     "INSERT INTO data_types (inet_t) VALUES($1)",
-    inet
+    inet,
   );
   const selectRes = await CLIENT.query(
     "SELECT inet_t FROM data_types WHERE inet_t=$1",
-    inet
+    inet,
   );
   assertEquals(selectRes.rows, [[inet]]);
 });
@@ -33,11 +33,11 @@ testClient(async function macaddr() {
   const macaddr = "08:00:2b:01:02:03";
   const insertRes = await CLIENT.query(
     "INSERT INTO data_types (macaddr_t) VALUES($1)",
-    macaddr
+    macaddr,
   );
   const selectRes = await CLIENT.query(
     "SELECT macaddr_t FROM data_types WHERE macaddr_t=$1",
-    macaddr
+    macaddr,
   );
   assertEquals(selectRes.rows, [[macaddr]]);
 });
@@ -46,11 +46,11 @@ testClient(async function cidr() {
   const cidr = "192.168.100.128/25";
   const insertRes = await CLIENT.query(
     "INSERT INTO data_types (cidr_t) VALUES($1)",
-    cidr
+    cidr,
   );
   const selectRes = await CLIENT.query(
     "SELECT cidr_t FROM data_types WHERE cidr_t=$1",
-    cidr
+    cidr,
   );
   assertEquals(selectRes.rows, [[cidr]]);
 });
@@ -93,7 +93,7 @@ testClient(async function regtype() {
 testClient(async function regrole() {
   const result = await CLIENT.query(
     `SELECT ($1)::regrole`,
-    TEST_CONNECTION_PARAMS.user
+    TEST_CONNECTION_PARAMS.user,
   );
   assertEquals(result.rows, [[TEST_CONNECTION_PARAMS.user]]);
 });

--- a/tests/encode.ts
+++ b/tests/encode.ts
@@ -11,7 +11,7 @@ function resetTimezoneOffset() {
 }
 
 function overrideTimezoneOffset(offset: number) {
-  Date.prototype.getTimezoneOffset = function() {
+  Date.prototype.getTimezoneOffset = function () {
     return offset;
   };
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -5,7 +5,7 @@ export function getTestClient(
   defSetupQueries?: Array<string>
 ) {
   return async function testClient(
-    t: Deno.TestFunction,
+    t: Deno.TestDefinition["fn"],
     setupQueries?: Array<string>
   ) {
     const fn = async () => {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -2,11 +2,11 @@ import { Client } from "../client.ts";
 
 export function getTestClient(
   client: Client,
-  defSetupQueries?: Array<string>
+  defSetupQueries?: Array<string>,
 ) {
   return async function testClient(
     t: Deno.TestDefinition["fn"],
-    setupQueries?: Array<string>
+    setupQueries?: Array<string>,
   ) {
     const fn = async () => {
       try {

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -9,7 +9,7 @@ import { TEST_CONNECTION_PARAMS, DEFAULT_SETUP } from "./constants.ts";
 async function testPool(
   t: (pool: Pool) => void | Promise<void>,
   setupQueries?: Array<string> | null,
-  lazy?: boolean
+  lazy?: boolean,
 ) {
   // constructing Pool instantiates the connections,
   // so this has to be constructed for each test.
@@ -76,12 +76,12 @@ testPool(
     assertEquals(POOL.available, 10);
     assertEquals(POOL.size, 10);
 
-    const result = qs.map(r => r.rows[0][1]);
+    const result = qs.map((r) => r.rows[0][1]);
     const expected = [...Array(25)].map((_, i) => i.toString());
     assertEquals(result, expected);
   },
   null,
-  true
+  true,
 );
 
 /**
@@ -114,7 +114,7 @@ testPool(async function manyQueries(POOL) {
   assertEquals(POOL.available, 10);
   assertEquals(POOL.size, 10);
 
-  const result = qs.map(r => r.rows[0][1]);
+  const result = qs.map((r) => r.rows[0][1]);
   const expected = [...Array(25)].map((_, i) => i.toString());
   assertEquals(result, expected);
 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -6,7 +6,7 @@ test(function testParseDsn() {
   let c: DsnResult;
 
   c = parseDsn(
-    "postgres://fizz:buzz@deno.land:8000/test_database?application_name=myapp"
+    "postgres://fizz:buzz@deno.land:8000/test_database?application_name=myapp",
   );
 
   assertEquals(c.driver, "postgres");

--- a/utils.ts
+++ b/utils.ts
@@ -16,9 +16,9 @@ export function readInt32BE(buffer: Uint8Array, offset: number): number {
 
   return (
     (buffer[offset] << 24) |
-    (buffer[offset + 1] << 16) |
-    (buffer[offset + 2] << 8) |
-    buffer[offset + 3]
+      (buffer[offset + 1] << 16) |
+      (buffer[offset + 2] << 8) |
+      buffer[offset + 3]
   );
 }
 
@@ -47,7 +47,7 @@ function md5(bytes: Uint8Array): string {
 export function hashMd5Password(
   password: string,
   username: string,
-  salt: Uint8Array
+  salt: Uint8Array,
 ): string {
   const innerHash = md5(encoder.encode(password + username));
   const innerBytes = encoder.encode(innerHash);
@@ -82,7 +82,7 @@ export function parseDsn(dsn: string): DsnResult {
     port: url.port,
     // remove leading slash from path
     database: url.pathname.slice(1),
-    params: Object.fromEntries(url.searchParams.entries())
+    params: Object.fromEntries(url.searchParams.entries()),
   };
 }
 


### PR DESCRIPTION
This PR closes #105.
- Run `deno fmt` for all TypeScript files (69e93cb)
- Bumped Deno to v0.39.0 in CI
- Bumped deno_std to v0.39.0
- Bumped checksum to v1.2.0
  - compilation of checksum@v1.0.1 fails on Deno@v0.39.0
- Fixed the `Pool.end` because it leaks resources ([8b73869](https://github.com/buildondata/deno-postgres/pull/106/commits/8b73869c72063dd33e6350936ad45473f1ca87b2#diff-abbe517e83766bfd209816919082cb37))
