### PR TITLE
Replace CI badge from Travis to Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # deno-postgres
 
-[![Build Status](https://travis-ci.com/buildondata/deno-postgres.svg?branch=master)](https://travis-ci.com/buildondata/deno-postgres)
+![ci](https://github.com/buildondata/deno-postgres/workflows/ci/badge.svg)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/deno-postgres/community)
 
 PostgreSQL driver for Deno.


### PR DESCRIPTION
@bartlomieju I realized that we forgot to update the CI badge in the readme.
This pr closes #67 