### PR TITLE
rename connection params host->hostname and change port type

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -1,12 +1,12 @@
 import { Connection } from "./connection.ts";
-import { ConnectionParams, IConnectionParams } from "./connection_params.ts";
+import { ConnectionOptions, createParams } from "./connection_params.ts";
 import { Query, QueryConfig, QueryResult } from "./query.ts";
 
 export class Client {
   protected _connection: Connection;
 
-  constructor(config?: IConnectionParams | string) {
-    const connectionParams = new ConnectionParams(config);
+  constructor(config?: ConnectionOptions | string) {
+    const connectionParams = createParams(config);
     this._connection = new Connection(connectionParams);
   }
 

--- a/connection.ts
+++ b/connection.ts
@@ -109,12 +109,11 @@ export class Connection {
     writer.addInt16(3).addInt16(0);
     const connParams = this.connParams;
     // TODO: recognize other parameters
-    (["user", "database", "application_name"] as Array<
-      keyof ConnectionParams
-    >).forEach(function (key) {
-      const val = connParams[key];
-      writer.addCString(key).addCString(val);
-    });
+    writer.addCString("user").addCString(connParams.user);
+    writer.addCString("database").addCString(connParams.database);
+    writer.addCString("application_name").addCString(
+      connParams.application_name,
+    );
 
     // eplicitly set utf-8 encoding
     writer.addCString("client_encoding").addCString("'utf-8'");
@@ -135,11 +134,8 @@ export class Connection {
   }
 
   async startup() {
-    const { host, port } = this.connParams;
-    this.conn = await Deno.connect({
-      port: parseInt(port, 10),
-      hostname: host,
-    });
+    const { port, hostname } = this.connParams;
+    this.conn = await Deno.connect({ port, hostname });
 
     this.bufReader = new BufReader(this.conn);
     this.bufWriter = new BufWriter(this.conn);

--- a/connection.ts
+++ b/connection.ts
@@ -112,7 +112,7 @@ export class Connection {
     writer.addCString("user").addCString(connParams.user);
     writer.addCString("database").addCString(connParams.database);
     writer.addCString("application_name").addCString(
-      connParams.application_name,
+      connParams.applicationName,
     );
 
     // eplicitly set utf-8 encoding

--- a/connection_params.ts
+++ b/connection_params.ts
@@ -44,7 +44,7 @@ export interface ConnectionParams {
   port: number;
   user: string;
   password?: string;
-  application_name: string;
+  applicationName: string;
   // TODO: support other params
 }
 
@@ -132,7 +132,7 @@ export function createParams(
     database: selectRequired(sources, "database"),
     hostname: selectRequired(sources, "hostname"),
     port: selectRequired(sources, "port"),
-    application_name: selectRequired(sources, "applicationName"),
+    applicationName: selectRequired(sources, "applicationName"),
     user: selectRequired(sources, "user"),
     password: select(sources, "password"),
   };

--- a/connection_params.ts
+++ b/connection_params.ts
@@ -18,7 +18,7 @@ function getPgEnv(): ConnectionOptions {
   }
 }
 
-function isDefined<T>(value: T): value is Exclude<T, undefined | null> {
+function isDefined<T>(value: T): value is NonNullable<T> {
   return value !== undefined && value !== null;
 }
 
@@ -58,7 +58,7 @@ function select<T extends keyof ConnectionOptions>(
 function selectRequired<T extends keyof ConnectionOptions>(
   sources: ConnectionOptions[],
   key: T,
-): Exclude<ConnectionOptions[T], undefined | null> {
+): NonNullable<ConnectionOptions[T]> {
   const result = select(sources, key);
 
   if (!isDefined(result)) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ config = {
   port: "5432",
   user: "user",
   database: "test",
-  application_name: "my_custom_app"
+  applicationName: "my_custom_app"
 };
 // alternatively
 config = "postgres://user@localhost:5432/test?application_name=my_custom_app";

--- a/pool.ts
+++ b/pool.ts
@@ -1,6 +1,10 @@
 import { PoolClient } from "./client.ts";
 import { Connection } from "./connection.ts";
-import { ConnectionParams, IConnectionParams } from "./connection_params.ts";
+import {
+  ConnectionOptions,
+  ConnectionParams,
+  createParams,
+} from "./connection_params.ts";
 import { DeferredStack } from "./deferred.ts";
 import { Query, QueryConfig, QueryResult } from "./query.ts";
 
@@ -13,11 +17,11 @@ export class Pool {
   private _lazy: boolean;
 
   constructor(
-    connectionParams: IConnectionParams,
+    connectionParams: ConnectionOptions,
     maxSize: number,
     lazy?: boolean,
   ) {
-    this._connectionParams = new ConnectionParams(connectionParams);
+    this._connectionParams = createParams(connectionParams);
     this._maxSize = maxSize;
     this._lazy = !!lazy;
     this._ready = this._startup();

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -3,5 +3,6 @@ export {
   assert,
   assertEquals,
   assertStrContains,
+  assertThrows,
   assertThrowsAsync,
 } from "https://deno.land/std@v0.42.0/testing/asserts.ts";

--- a/tests/connection_params.ts
+++ b/tests/connection_params.ts
@@ -1,7 +1,6 @@
 const { test } = Deno;
-import { assertEquals, assertStrContains } from "../test_deps.ts";
+import { assertEquals, assertThrows } from "../test_deps.ts";
 import { createParams } from "../connection_params.ts";
-import { assertThrows } from "https://deno.land/std@v0.42.0/testing/asserts.ts";
 
 function withEnv(obj: Record<string, string>, fn: () => void) {
   return () => {
@@ -65,7 +64,7 @@ test("dsnStyleParametersWithApplicationName", function () {
   assertEquals(p.database, "deno_postgres");
   assertEquals(p.user, "some_user");
   assertEquals(p.hostname, "some_host");
-  assertEquals(p.application_name, "test_app");
+  assertEquals(p.applicationName, "test_app");
   assertEquals(p.port, 10101);
 });
 

--- a/tests/connection_params.ts
+++ b/tests/connection_params.ts
@@ -1,78 +1,142 @@
 const { test } = Deno;
 import { assertEquals, assertStrContains } from "../test_deps.ts";
-import { ConnectionParams } from "../connection_params.ts";
+import { createParams } from "../connection_params.ts";
+import { assertThrows } from "https://deno.land/std@v0.42.0/testing/asserts.ts";
 
-test("dsnStyleParameters", async function () {
-  const p = new ConnectionParams(
+function withEnv(obj: Record<string, string>, fn: () => void) {
+  return () => {
+    const getEnv = Deno.env.get;
+
+    Deno.env.get = (key: string) => {
+      return obj[key] || getEnv(key);
+    };
+
+    try {
+      fn();
+    } finally {
+      Deno.env.get = getEnv;
+    }
+  };
+}
+
+function withNotAllowedEnv(fn: () => void) {
+  return () => {
+    const getEnv = Deno.env.get;
+
+    Deno.env.get = (_key: string) => {
+      throw new Deno.errors.PermissionDenied("");
+    };
+
+    try {
+      fn();
+    } finally {
+      Deno.env.get = getEnv;
+    }
+  };
+}
+
+test("dsnStyleParameters", function () {
+  const p = createParams(
     "postgres://some_user@some_host:10101/deno_postgres",
   );
 
   assertEquals(p.database, "deno_postgres");
   assertEquals(p.user, "some_user");
-  assertEquals(p.host, "some_host");
-  assertEquals(p.port, "10101");
+  assertEquals(p.hostname, "some_host");
+  assertEquals(p.port, 10101);
+});
+
+test("dsnStyleParametersWithInvalidPortPort", function () {
+  assertThrows(
+    () =>
+      createParams(
+        "postgres://some_user@some_host:abc/deno_postgres",
+      ),
+    undefined,
+    "Invalid URL",
+  );
 });
 
 test("objectStyleParameters", async function () {
-  const p = new ConnectionParams({
+  const p = createParams({
     user: "some_user",
-    host: "some_host",
-    port: "10101",
+    hostname: "some_host",
+    port: 10101,
     database: "deno_postgres",
   });
 
   assertEquals(p.database, "deno_postgres");
   assertEquals(p.user, "some_user");
-  assertEquals(p.host, "some_host");
-  assertEquals(p.port, "10101");
+  assertEquals(p.hostname, "some_host");
+  assertEquals(p.port, 10101);
 });
 
-// TODO: add test when env is not allowed
-test("envParameters", async function () {
-  const currentEnv = Deno.env;
+test(
+  "envParameters",
+  withEnv({
+    PGUSER: "some_user",
+    PGHOST: "some_host",
+    PGPORT: "10101",
+    PGDATABASE: "deno_postgres",
+  }, function () {
+    const p = createParams();
+    assertEquals(p.database, "deno_postgres");
+    assertEquals(p.user, "some_user");
+    assertEquals(p.hostname, "some_host");
+    assertEquals(p.port, 10101);
+  }),
+);
 
-  currentEnv.set("PGUSER", "some_user");
-  currentEnv.set("PGHOST", "some_host");
-  currentEnv.set("PGPORT", "10101");
-  currentEnv.set("PGDATABASE", "deno_postgres");
+test(
+  "envParametersWithInvalidPort",
+  withEnv({
+    PGUSER: "some_user",
+    PGHOST: "some_host",
+    PGPORT: "abc",
+    PGDATABASE: "deno_postgres",
+  }, function () {
+    const error = assertThrows(
+      () => createParams(),
+      undefined,
+      "Invalid port NaN",
+    );
+    assertEquals(error.name, "ConnectionParamsError");
+  }),
+);
 
-  const p = new ConnectionParams();
-  assertEquals(p.database, "deno_postgres");
-  assertEquals(p.user, "some_user");
-  assertEquals(p.host, "some_host");
-  assertEquals(p.port, "10101");
+test(
+  "envParametersWhenNotAllowed",
+  withNotAllowedEnv(function () {
+    const p = createParams({
+      database: "deno_postgres",
+      user: "deno_postgres",
+    });
 
-  // clear out env
-  currentEnv.set("PGUSER", "");
-  currentEnv.set("PGHOST", "");
-  currentEnv.set("PGPORT", "");
-  currentEnv.set("PGDATABASE", "");
-});
+    assertEquals(p.database, "deno_postgres");
+    assertEquals(p.user, "deno_postgres");
+    assertEquals(p.hostname, "127.0.0.1");
+    assertEquals(p.port, 5432);
+  }),
+);
 
 test("defaultParameters", async function () {
-  const p = new ConnectionParams({
+  const p = createParams({
     database: "deno_postgres",
     user: "deno_postgres",
   });
   assertEquals(p.database, "deno_postgres");
   assertEquals(p.user, "deno_postgres");
-  assertEquals(p.host, "127.0.0.1");
-  assertEquals(p.port, "5432");
+  assertEquals(p.hostname, "127.0.0.1");
+  assertEquals(p.port, 5432);
   assertEquals(p.password, undefined);
 });
 
 test("requiredParameters", async function () {
-  let thrown = false;
+  const error = assertThrows(
+    () => createParams(),
+    undefined,
+    "Missing connection parameters: database, user",
+  );
 
-  try {
-    new ConnectionParams();
-  } catch (e) {
-    thrown = true;
-    assertEquals(e.name, "ConnectionParamsError");
-    assertStrContains(
-      e.message,
-      "Missing connection parameters: database, user",
-    );
-  }
-  assertEquals(thrown, true);
+  assertEquals(error.name, "ConnectionParamsError");
 });

--- a/tests/connection_params.ts
+++ b/tests/connection_params.ts
@@ -46,7 +46,41 @@ test("dsnStyleParameters", function () {
   assertEquals(p.port, 10101);
 });
 
-test("dsnStyleParametersWithInvalidPortPort", function () {
+test("dsnStyleParametersWithoutExplicitPort", function () {
+  const p = createParams(
+    "postgres://some_user@some_host/deno_postgres",
+  );
+
+  assertEquals(p.database, "deno_postgres");
+  assertEquals(p.user, "some_user");
+  assertEquals(p.hostname, "some_host");
+  assertEquals(p.port, 5432);
+});
+
+test("dsnStyleParametersWithApplicationName", function () {
+  const p = createParams(
+    "postgres://some_user@some_host:10101/deno_postgres?application_name=test_app",
+  );
+
+  assertEquals(p.database, "deno_postgres");
+  assertEquals(p.user, "some_user");
+  assertEquals(p.hostname, "some_host");
+  assertEquals(p.application_name, "test_app");
+  assertEquals(p.port, 10101);
+});
+
+test("dsnStyleParametersWithInvalidDriver", function () {
+  assertThrows(
+    () =>
+      createParams(
+        "somedriver://some_user@some_host:10101/deno_postgres",
+      ),
+    undefined,
+    "Supplied DSN has invalid driver: somedriver.",
+  );
+});
+
+test("dsnStyleParametersWithInvalidPort", function () {
   assertThrows(
     () =>
       createParams(
@@ -57,7 +91,7 @@ test("dsnStyleParametersWithInvalidPortPort", function () {
   );
 });
 
-test("objectStyleParameters", async function () {
+test("objectStyleParameters", function () {
   const p = createParams({
     user: "some_user",
     hostname: "some_host",
@@ -119,7 +153,7 @@ test(
   }),
 );
 
-test("defaultParameters", async function () {
+test("defaultParameters", function () {
   const p = createParams({
     database: "deno_postgres",
     user: "deno_postgres",
@@ -131,7 +165,7 @@ test("defaultParameters", async function () {
   assertEquals(p.password, undefined);
 });
 
-test("requiredParameters", async function () {
+test("requiredParameters", function () {
   const error = assertThrows(
     () => createParams(),
     undefined,

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -19,5 +19,5 @@ export const TEST_CONNECTION_PARAMS: ConnectionParams = {
   database: "deno_postgres",
   hostname: "127.0.0.1",
   port: 5432,
-  application_name: "deno_postgres",
+  applicationName: "deno_postgres",
 };

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -1,3 +1,5 @@
+import { ConnectionParams } from "../connection_params.ts";
+
 export const DEFAULT_SETUP = [
   "DROP TABLE IF EXISTS ids;",
   "CREATE TABLE ids(id integer);",
@@ -11,10 +13,11 @@ export const DEFAULT_SETUP = [
   "INSERT INTO bytes VALUES(E'foo\\\\000\\\\200\\\\\\\\\\\\377')",
 ];
 
-export const TEST_CONNECTION_PARAMS = {
+export const TEST_CONNECTION_PARAMS: ConnectionParams = {
   user: "test",
   password: "test",
   database: "deno_postgres",
-  host: "127.0.0.1",
-  port: "5432",
+  hostname: "127.0.0.1",
+  port: 5432,
+  application_name: "deno_postgres",
 };

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -12,7 +12,7 @@ test("testParseDsn", function () {
   assertEquals(c.driver, "postgres");
   assertEquals(c.user, "fizz");
   assertEquals(c.password, "buzz");
-  assertEquals(c.host, "deno.land");
+  assertEquals(c.hostname, "deno.land");
   assertEquals(c.port, "8000");
   assertEquals(c.database, "test_database");
   assertEquals(c.params.application_name, "myapp");
@@ -22,7 +22,7 @@ test("testParseDsn", function () {
   assertEquals(c.driver, "postgres");
   assertEquals(c.user, "");
   assertEquals(c.password, "");
-  assertEquals(c.host, "deno.land");
+  assertEquals(c.hostname, "deno.land");
   assertEquals(c.port, "");
   assertEquals(c.database, "test_database");
 });

--- a/utils.ts
+++ b/utils.ts
@@ -62,7 +62,7 @@ export interface DsnResult {
   driver: string;
   user: string;
   password: string;
-  host: string;
+  hostname: string;
   port: string;
   database: string;
   params: {
@@ -78,7 +78,7 @@ export function parseDsn(dsn: string): DsnResult {
     driver: url.protocol.slice(0, url.protocol.length - 1),
     user: url.username,
     password: url.password,
-    host: url.hostname,
+    hostname: url.hostname,
     port: url.port,
     // remove leading slash from path
     database: url.pathname.slice(1),


### PR DESCRIPTION
Closes #113 

I took the liberty to also refactor the creation of the connection_params.ts params because I found the code a bit hard to follow and modify. Let me know what you think.

I also think `parseDsn` should be moved into `connection_params.ts` and tested through createParams instead. If you agree, I'll do that as well.