### PR TITLE
[Fix] Connection string parsing

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -71,11 +71,13 @@ export interface DsnResult {
 }
 
 export function parseDsn(dsn: string): DsnResult {
-  const url = new URL(dsn);
+  //URL object won't parse the URL if it doesn't recognize the protocol
+  //This line replaces the protocol with http and then leaves it up to URL
+  const [protocol, stripped_url] = dsn.match(/(?:(?!:\/\/).)+/g) ?? ["", ""];
+  const url = new URL(`http:${stripped_url}`);
 
   return {
-    // remove trailing colon
-    driver: url.protocol.slice(0, url.protocol.length - 1),
+    driver: protocol,
     user: url.username,
     password: url.password,
     hostname: url.hostname,


### PR DESCRIPTION
The URL api is aligned to match the one in the browser, which mean that in both cases passing a connection string with the following format:
```log
postgres://fizz:buzz@deno.land:8000/test_database?application_name=myapp
```
The URL api won't parse the url correctly due to the API not recognizing the protocol/driver in the url, that is why this PR replaces the protocol with `http` in order to parse the url correctly through the URL api.