### PR TITLE
Add per connection queue to prevent concurrent queries and unexpected frames.

### DIFF
--- a/tests/queries.ts
+++ b/tests/queries.ts
@@ -136,3 +136,21 @@ testClient(async function multiQueryWithManyQueryTypeArray() {
 
   assertEquals(result[2].rows.length, 2);
 });
+
+testClient(async function transactionWithConcurrentQueries() {
+  const result = await CLIENT.query("BEGIN");
+
+  assertEquals(result.rows.length, 0);
+  const concurrentCount = 5;
+  const queries = [...Array(concurrentCount)].map((_, i) => {
+    return CLIENT.query({
+      text: "INSERT INTO ids (id) VALUES ($1) RETURNING id;",
+      args: [i],
+    });
+  });
+  const results = await Promise.all(queries);
+
+  results.forEach((r, i) => {
+    assertEquals(r.rows[0][0], i);
+  });
+});


### PR DESCRIPTION
I was getting the following error when trying to perform multiple concurrent queries:

```
Error: Unexpected frame: Z
    at Connection._simpleQuery (file:///Users/joe/code/deno-postgres/connection.ts:305:15)
    at async Connection.query (file:///Users/joe/code/deno-postgres/connection.ts:526:14)
    at async PoolClient.query (file:///Users/joe/code/deno-postgres/client.ts:60:12)
```

I'm opening this PR to discuss. I think that queuing is a bit more complicated than what is being handled in my changes and needs to be thought through more.